### PR TITLE
fix(ApiGatewayProxyHandler): use implicit type for decorator

### DIFF
--- a/src/decorator/handler/index.ts
+++ b/src/decorator/handler/index.ts
@@ -1,7 +1,6 @@
 import * as handlers from "../../handler";
-import { APIGatewayProxyEvent, Context, APIGatewayProxyResult } from "aws-lambda";
 
-type Handler = (event: APIGatewayProxyEvent, context: Context) => Promise<APIGatewayProxyResult>;
+type Handler = (_target: unknown, _propertyName: string, propertyDescriptor: PropertyDescriptor) => PropertyDescriptor;
 
 export function APIGatewayProxyHandler(args?: handlers.APIGatewayProxyHandlerArguments): Handler {
     const handler = new handlers.APIGatewayProxyHandler(args);


### PR DESCRIPTION
Used implicit type for decorator inferred by Typescript from decorator binding - https://github.com/enter-at/node-aws-lambda-handlers/blob/9ada1b1c1e07b0dc9e8359d3486289f0af96e6c0/src/decorator/handler/index.ts#L7